### PR TITLE
Fix touchmove preventDefault on non-cancelable events (#189)

### DIFF
--- a/src/ci360.service.js
+++ b/src/ci360.service.js
@@ -596,7 +596,7 @@ class CI360Viewer {
     // Normal single-finger drag for rotation
     if (!this.isClicked || !event.touches || !event.touches[0]) return;
     const { pageX, pageY } = event.touches[0];
-    event.preventDefault();
+    if (event.cancelable) event.preventDefault();
 
     this.drag(pageX, pageY);
   }

--- a/src/utils/zoom/gestures.js
+++ b/src/utils/zoom/gestures.js
@@ -56,7 +56,7 @@ export class GestureRecognizer {
 
     // Two-finger pinch start
     if (event.touches.length === 2) {
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
       this.isPinching = true;
       this.initialPinchDistance = this._getPinchDistance(event.touches[0], event.touches[1]);
       this.pinchBaseZoom = typeof this.getZoom === 'function' ? this.getZoom() : 1;
@@ -77,7 +77,7 @@ export class GestureRecognizer {
 
       if (dt < 300 && dx < 30 && dy < 30) {
         // Double-tap detected
-        event.preventDefault();
+        if (event.cancelable) event.preventDefault();
         event.stopPropagation(); // Prevent service touchStart from setting drag state
         this.lastTapTime = 0;
         if (typeof this.onDoubleTap === 'function') {
@@ -97,7 +97,7 @@ export class GestureRecognizer {
 
     // Pinch zoom
     if (this.isPinching && event.touches.length === 2) {
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
 
       const currentDistance = this._getPinchDistance(event.touches[0], event.touches[1]);
       if (this.initialPinchDistance === 0) {
@@ -123,7 +123,7 @@ export class GestureRecognizer {
       const currentZoom = typeof this.getZoom === 'function' ? this.getZoom() : 1;
       if (currentZoom <= 1) return; // Let 360 rotation handle it
 
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
       const touch = event.touches[0];
       const dx = touch.pageX - this.lastTouchX;
       const dy = touch.pageY - this.lastTouchY;


### PR DESCRIPTION
Guard preventDefault() with event.cancelable check in touchMove and GestureRecognizer to suppress the browser's '[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false' warning when a scroll gesture is already in progress on touch devices.